### PR TITLE
Fix: add new column in Google spreadsheet

### DIFF
--- a/src/app/api/data_parser/route.ts
+++ b/src/app/api/data_parser/route.ts
@@ -61,6 +61,7 @@ function dataProcess(data: string[]) {
     'thirdPlaceScore',
     'fourthPlaceName',
     'fourthPlaceScore',
+    'unknown',
     'checksum',
     'comment',
     'seasonLog',

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -8,6 +8,7 @@ export interface DataGroup {
   thirdPlaceScore: number;
   fourthPlaceName: string;
   fourthPlaceScore: number;
+  unknown: string;
   checksum: number;
   comment: string;
   seasonLog: string;


### PR DESCRIPTION
This implements:

- Make new column for newly added Google spreadsheet column